### PR TITLE
Create a Ubuntu18.04r3.6 tagged image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ refernces:
         apt2upg=$( sudo apt-get -s dist-upgrade | grep -Po "^[[:digit:]]+ (?=upgraded)" ) 
 
         # Check if there are old r packages to be upgraded. If not convert NULL to 0
-        r2upg=$( sudo Rscript -e ' r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)'  )
+        r2upg=$( sudo Rscript -e 'options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)'  )
 
         # Print information
         printf "Pakages to be upgraded: \n apt: $apt2upg  \n r  : $r2upg \n"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ refernces:
         apt2upg=$( sudo apt-get -s dist-upgrade | grep -Po "^[[:digit:]]+ (?=upgraded)" ) 
 
         # Check if there are old r packages to be upgraded. If not convert NULL to 0
-        r2upg=$( sudo Rscript -e "options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)"  )
+        r2upg=$( sudo Rscript -e "options(repos = 'https://cloud.r-project.org/'); r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)"  )
 
         # Print information
         printf "Pakages to be upgraded: \n apt: $apt2upg  \n r  : $r2upg \n"
@@ -129,7 +129,7 @@ jobs:
               apt2upg=$( sudo apt-get -s dist-upgrade | grep -Po "^[[:digit:]]+ (?=upgraded)" ) 
 
               # Check if there are old r packages to be upgraded. If not convert NULL to 0
-              r2upg=$( sudo Rscript -e "options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)"  )
+              r2upg=$( sudo Rscript -e "options(repos = 'https://cloud.r-project.org/'); r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)"  )
 
               # Print information
               printf "Pakages to be upgraded: \n apt: $apt2upg  \n r  : $r2upg \n"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
               apt2upg=$( sudo apt-get -s dist-upgrade | grep -Po "^[[:digit:]]+ (?=upgraded)" ) 
 
               # Check if there are old r packages to be upgraded. If not convert NULL to 0
-              r2upg=$( sudo Rscript -e ' r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)'  )
+              r2upg=$( sudo Rscript -e 'options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)'  )
 
               # Print information
               printf "Pakages to be upgraded: \n apt: $apt2upg  \n r  : $r2upg \n"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,9 @@ version: 2.1
 
 # ********** ********** ********** ********** ********** ********** ********** ********** #
 
-# Pipeline parameter to run conditional workflows - 21 April 2020
+# Pipeline parameters
 parameters:
+  # to run conditional workflows - 21 April 2020
   run_on_commit:
     type: boolean
     default: true
@@ -27,15 +28,18 @@ parameters:
   run_to_test_img:
     type: boolean
     default: false
-
-
+    
 # Code references 
 refernces:
 
 # Common environmental variables
   env_vars: &env_vars
-    IMAGE_NAME: eeg-docker    # Name of the project on docker
-    IMAGE_TAG: r-v4     #  Docker version tag
+    #IMAGE_TAG: << pipeline.parameters.IMAGE_TAG >>
+    #REPO_NAME: << pipeline.parameters.REPO_NAME >>
+    #IMAGE_NAME: << pipeline.parameters.IMAGE_NAME >>
+    IMAGE_TAG: ubuntu18.04r3.6     #  Docker version tag :$IMAGE_TAG
+    REPO_NAME: eeg-docker
+    #IMAGE_NAME: $DOCKER_USERNAME/$REPO_NAME # Concat not working  # Name of the project on docker
 
 # Code for building and push the docker to docker.com
   build_docker: &build_docker
@@ -46,9 +50,13 @@ refernces:
           docker build ./ --no-cache=true  \
             --build-arg VCS_REF=$(git rev-parse --short HEAD) \
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-            -t $DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG
+            -t $DOCKER_USERNAME/$REPO_NAME:$IMAGE_TAG
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker push $DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG 
+          docker push $DOCKER_USERNAME/$REPO_NAME:$IMAGE_TAG
+          
+          # Add here additional tags
+          #docker tag $DOCKER_USERNAME/$REPO_NAME:$IMAGE_TAG $DOCKER_USERNAME/$REPO_NAME:latest
+          #docker push $DOCKER_USERNAME/$REPO_NAME:latest 
 
           # docker login -u $DOCKER_USERNAME --password-stdin $DOCKER_PASSWORD
       #--build-arg BUILD_VERSION=${build_version} \  
@@ -104,7 +112,7 @@ jobs:
 # Pull the image and test if it works.      
   test_image:
     docker:
-      - image: $DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG # Require env_vars
+      - image: $DOCKER_USERNAME/$REPO_NAME:$IMAGE_TAG # Require pipeline parameters
     environment:
       <<: *env_vars # Import here the env_variables. They are used in the name of the docker image
     steps:
@@ -113,7 +121,7 @@ jobs:
  # Check if an update of docker is needed, if so run the build_deploy_docker job      
   check_update_docker: 
     docker:
-      - image: $DOCKER_USERNAME/$IMAGE_NAME:$IMAGE_TAG
+      - image: $DOCKER_USERNAME/$REPO_NAME:$IMAGE_TAG
     environment:
       <<: *env_vars # Import here the env_variables. They are used in the name of the docker image and in the building process
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,11 @@ version: 2.1
 # Requirements:
 #
 # Make sure to set envirnomental variables in circle ci (or as resources in your organization's org-global Context):  
-# - DOCKER_USERNAME : the username  used on docker.com
-# - DOCKER_PASSWORD : the password  used on docker.com
-# - DOCKER_TOKEN    : a Circleci personal o Project API token (https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token)
-# - DOCKER_TOKEN_PERSONAL_AM: a Circleci personal API token - A personal one is needed to trigger workflows with API v2. (The value is added in the project environment variables)
+# - DOCKER_USERNAME: the username  used on docker.com
+# - DOCKER_PASSWORD: the password  used on docker.com
+# - DOCKER_TOKEN_PERSONAL_AM: a Circleci personal API token - A personal one is needed to trigger workflows with API v2. 
+#                     (The value is added in the project environment variables)
+#                     (https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token)
 # ********** ********** ********** ********** ********** ********** ********** ********** #
 
 # ********** ********** ********** ********** ********** ********** ********** ********** #
@@ -34,7 +35,7 @@ refernces:
 # Common environmental variables
   env_vars: &env_vars
     IMAGE_NAME: eeg-docker    # Name of the project on docker
-    IMAGE_TAG: latest     #  Docker version tag
+    IMAGE_TAG: r-v4     #  Docker version tag
 
 # Code for building and push the docker to docker.com
   build_docker: &build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ refernces:
         apt2upg=$( sudo apt-get -s dist-upgrade | grep -Po "^[[:digit:]]+ (?=upgraded)" ) 
 
         # Check if there are old r packages to be upgraded. If not convert NULL to 0
-        r2upg=$( sudo Rscript -e 'options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)'  )
+        r2upg=$( sudo Rscript -e "options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)"  )
 
         # Print information
         printf "Pakages to be upgraded: \n apt: $apt2upg  \n r  : $r2upg \n"
@@ -129,7 +129,7 @@ jobs:
               apt2upg=$( sudo apt-get -s dist-upgrade | grep -Po "^[[:digit:]]+ (?=upgraded)" ) 
 
               # Check if there are old r packages to be upgraded. If not convert NULL to 0
-              r2upg=$( sudo Rscript -e 'options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)'  )
+              r2upg=$( sudo Rscript -e "options(repos = 'https://cloud.r-project.org/'; r_upg <-nrow( old.packages() ) ; if ( is.null(r_upg) ) { r_upg =0 }  ; cat(r_upg)"  )
 
               # Print information
               printf "Pakages to be upgraded: \n apt: $apt2upg  \n r  : $r2upg \n"

--- a/Docker-quick-guide.md
+++ b/Docker-quick-guide.md
@@ -1,0 +1,180 @@
+# Quick guide to the docker command 
+
+## Introduction
+Info on the `docker` usage, command, options, and parameters can be obtained running
+```
+$docker help
+```
+or on the [Reference documentation](https://docs.docker.com/reference/) on the docker.com website.
+
+Among the commands (execute in the shell as `docker command_name`), those are the usefull ones:
+
+Command | Description
+--------| ------------------------
+build       |Build an image from a Dockerfile
+images      |List images
+ps          |List containers
+restart     |Restart one or more containers
+run         |Run a command in a new container
+stats       |Display a live stream of container(s) resource usage statistics
+stop        |Stop one or more running containers
+
+## The docker service
+
+In the shell, you can check the status of the docker service running (you might need to `sudo` it) using
+```
+$ service docker status
+```
+If the docker service is not running, you can start it with (you might need to `sudo` it)
+```
+$ service docker start
+```
+
+## Images and containers
+
+You can have a list of the downloaded images and containers, respectivelly via
+
+```
+$ docker images
+$ docker ps
+``` 
+If the `images` command output an empty list it means that you have not downloaded  any image yet. But you should have a demo `hello-world` one already installed by default.
+If the `ps` command output an empty list it means that you have not run any container yet.
+
+You can download a specific tagged image with 
+
+```
+$ docker pull manicaeeg/eeg-docker:tag_name
+```
+
+E.g:
+
+```
+$ docker pull manicaeeg/eeg-docker:latest
+$ docker pull manicaeeg/eeg-docker:ubuntu18.04r4.0
+$ docker pull manicaeeg/eeg-docker:ubuntu18.04r3.6
+```
+
+## Run an image
+
+To run a specific image in a new container (i.e. a new local virtual machine that run the selected image) you can use:
+
+```
+$ docker run [OPTIONS] IMAGE[:TAG|@DIGEST] [COMMAND] [ARG...]
+```
+Where the `IMAGE[:TAG|@DIGEST]` is among those downloaded and listed with `docker images`.
+E.g. (the order of parameters is important!)
+```
+$ docker run --name container_custom_name -it  manicaeeg/eeg-docker:latest
+```
+With the `-it` flag you will enter directly into the shell of the newly started container shell. To exit the container, you just need to write in the shell: `exit`. This will shut down the container.
+
+For more info on the `run` command, see its [Reference page](https://docs.docker.com/engine/reference/run/) on the docker website.
+
+## Interact with the container
+
+You can also control its execution from another instance of the shell. There you can verify running `docker ps` that the previous command actually was executed correctly and a new container is now present with the name you just set.
+
+You can start, stop and restart the container without enter its shell with:
+```
+sudo docker start eeg-docker -i
+sudo docker stop eeg-docker
+sudo docker restart eeg-docker
+```
+
+You can enter a running container in one those two way:
+
+```
+docker exec -it container_id bash
+docker exec -it container_custom_name base
+```
+where the `container_custom_name` is the custom one you specified in the `run` command with `--name container_custom_name`.
+
+You can then run commands in this container (e.g. clone locally a git repository) and perform tests locally.
+
+
+## docker help
+
+For reference, this is the output of the `docker help` command:
+
+```
+Usage:  docker [OPTIONS] COMMAND
+
+A self-sufficient runtime for containers
+
+Options:
+      --config string      Location of client config files (default "/home/orion42/.docker")
+  -c, --context string     Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and        
+                           default context set with "docker context use")
+  -D, --debug              Enable debug mode
+  -H, --host list          Daemon socket(s) to connect to
+  -l, --log-level string   Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
+      --tls                Use TLS; implied by --tlsverify
+      --tlscacert string   Trust certs signed only by this CA (default "/home/orion42/.docker/ca.pem")
+      --tlscert string     Path to TLS certificate file (default "/home/orion42/.docker/cert.pem")
+      --tlskey string      Path to TLS key file (default "/home/orion42/.docker/key.pem")
+      --tlsverify          Use TLS and verify the remote
+  -v, --version            Print version information and quit
+
+Management Commands:
+  builder     Manage builds
+  config      Manage Docker configs
+  container   Manage containers
+  context     Manage contexts
+  engine      Manage the docker engine
+  image       Manage images
+  network     Manage networks
+  node        Manage Swarm nodes
+  plugin      Manage plugins
+  secret      Manage Docker secrets
+  service     Manage services
+  stack       Manage Docker stacks
+  swarm       Manage Swarm
+  system      Manage Docker
+  trust       Manage trust on Docker images
+  volume      Manage volumes
+
+Commands:
+  attach      Attach local standard input, output, and error streams to a running container
+  build       Build an image from a Dockerfile
+  commit      Create a new image from a container's changes
+  cp          Copy files/folders between a container and the local filesystem
+  create      Create a new container
+  diff        Inspect changes to files or directories on a container's filesystem
+  events      Get real time events from the server
+  exec        Run a command in a running container
+  export      Export a container's filesystem as a tar archive
+  history     Show the history of an image
+  images      List images
+  import      Import the contents from a tarball to create a filesystem image
+  info        Display system-wide information
+  inspect     Return low-level information on Docker objects
+  kill        Kill one or more running containers
+  load        Load an image from a tar archive or STDIN
+  login       Log in to a Docker registry
+  logout      Log out from a Docker registry
+  logs        Fetch the logs of a container
+  pause       Pause all processes within one or more containers
+  port        List port mappings or a specific mapping for the container
+  ps          List containers
+  pull        Pull an image or a repository from a registry
+  push        Push an image or a repository to a registry
+  rename      Rename a container
+  restart     Restart one or more containers
+  rm          Remove one or more containers
+  rmi         Remove one or more images
+  run         Run a command in a new container
+  save        Save one or more images to a tar archive (streamed to STDOUT by default)
+  search      Search the Docker Hub for images
+  start       Start one or more stopped containers
+  stats       Display a live stream of container(s) resource usage statistics
+  stop        Stop one or more running containers
+  tag         Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+  top         Display the running processes of a container
+  unpause     Unpause all processes within one or more containers
+  update      Update configuration of one or more containers
+  version     Show the Docker version information
+  wait        Block until one or more containers stop, then print their exit codes
+
+Run 'docker COMMAND --help' for more information on a command.
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,13 @@ LABEL org.label-schema.vcs-ref=$VCS_REF
 # git ssh tar gzip ca-certificates are needed for circleci : https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
 # curl is needed for remote trigger the checks
 
+#sudo Rscript -e 'getOption("repos")'; \
+#sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r); getOption("repos")' \
+  
 RUN \
-  sudo Rscript -e 'getOption("repos")'; \
-  sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r); getOption("repos")' \
   sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
 RUN \
-  sudo Rscript -e 'getOption("repos"); update.packages(ask = FALSE)'
+  sudo Rscript -e 'getOption("repos"); update.packages(ask = FALSE,repos = "http://cran.us.r-project.org")'
 
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ LABEL org.label-schema.vcs-ref=$VCS_REF
 
 RUN \
   sudo Rscript -e 'getOption("repos")'; \
-  sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
+  sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r); getOption("repos")' \
   sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
 RUN \
-  sudo Rscript -e 'update.packages(ask = FALSE)'
+  sudo Rscript -e 'getOption("repos"); update.packages(ask = FALSE)'
 
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,6 @@ LABEL org.label-schema.vcs-ref=$VCS_REF
 # git ssh tar gzip ca-certificates are needed for circleci : https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
 # curl is needed for remote trigger the checks
 
-#sudo Rscript -e 'getOption("repos")'; \
-#sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r); getOption("repos")' \
-  
-RUN \
-  sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
-RUN \
-  sudo Rscript -e 'getOption("repos"); update.packages(ask = FALSE,repos = "http://cran.us.r-project.org")'
-
-
 RUN \
   apt-get update -qq && \
   apt-get install -y -qq --no-install-recommends \
@@ -75,11 +66,12 @@ RUN \
 # Last lines delete temporary files and cache
 
 # Set the default repository for CRAN and install devtools
+# The default is @CRAN@. It can be changed with:
 # sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
-#RUN \
-#    sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
-#RUN \
-#    sudo Rscript -e 'update.packages(ask = FALSE)'
+# but settings are not saved in different instances of the console.
+RUN \
+  sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' ; \
+  sudo Rscript -e 'update.packages(ask = FALSE,repos = "http://cran.us.r-project.org")'
 
 # Check if there are apt or r packages to be upgraded
 #RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,9 @@ RUN \
 # Last lines delete temporary files and cache
 
 # Set the default repository for CRAN and install devtools
+# sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
 RUN \
-    sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
-    sudo Rscript -e 'install.packages("devtools")' && \
+    sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' && \
     sudo Rscript -e 'update.packages(ask = FALSE)'
 
 # Check if there are apt or r packages to be upgraded

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,14 @@ LABEL org.label-schema.vcs-ref=$VCS_REF
 # curl is needed for remote trigger the checks
 
 RUN \
+  sudo Rscript -e 'getOption("repos")'; \
+  sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
+  sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
+RUN \
+  sudo Rscript -e 'update.packages(ask = FALSE)'
+
+
+RUN \
   apt-get update -qq && \
   apt-get install -y -qq --no-install-recommends \
   apt-utils \
@@ -67,10 +75,10 @@ RUN \
 
 # Set the default repository for CRAN and install devtools
 # sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
-RUN \
-    sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
-RUN \
-    sudo Rscript -e 'update.packages(ask = FALSE)'
+#RUN \
+#    sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
+#RUN \
+#    sudo Rscript -e 'update.packages(ask = FALSE)'
 
 # Check if there are apt or r packages to be upgraded
 #RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,11 +67,12 @@ RUN \
 
 # Set the default repository for CRAN and install devtools
 # The default is @CRAN@. It can be changed with:
-# sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
+# sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "https://cloud.r-project.org/" ; options(repos = r)' \
+# or sudo Rscript -e "options(repos = 'https://cloud.r-project.org/')"
 # but settings are not saved in different instances of the console.
 RUN \
-  sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' ; \
-  sudo Rscript -e 'update.packages(ask = FALSE,repos = "http://cran.us.r-project.org")'
+  sudo Rscript -e 'install.packages("devtools",repos = "https://cloud.r-project.org/")' ; \
+  sudo Rscript -e 'update.packages(ask = FALSE,repos = "https://cloud.r-project.org/")'
 
 # Check if there are apt or r packages to be upgraded
 #RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,11 @@ RUN \
   && rm -rf /var/lib/apt/lists/*
 # Last lines delete temporary files and cache
 
+# Set the default repository for CRAN and install devtools
 RUN \
+    sudo Rscript -e 'r = getOption("repos")' && \
+    sudo Rscript -e 'r["CRAN"] = "http://cran.us.r-project.org"' && \
+    sudo Rscript -e 'options(repos = r)' \
     sudo Rscript -e 'install.packages("devtools")' && \
     sudo Rscript -e 'update.packages(ask = FALSE)'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ RUN \
 # Set the default repository for CRAN and install devtools
 # sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
 RUN \
-    sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' && \
+    sudo Rscript -e 'install.packages("devtools",repos = "http://cran.us.r-project.org")' 
+RUN \
     sudo Rscript -e 'update.packages(ask = FALSE)'
 
 # Check if there are apt or r packages to be upgraded

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,7 @@ RUN \
 
 # Set the default repository for CRAN and install devtools
 RUN \
-    sudo Rscript -e 'r = getOption("repos")' && \
-    sudo Rscript -e 'r["CRAN"] = "http://cran.us.r-project.org"' && \
-    sudo Rscript -e 'options(repos = r)' \
+    sudo Rscript -e 'r = getOption("repos"); r["CRAN"] = "http://cran.us.r-project.org" ; options(repos = r)' \
     sudo Rscript -e 'install.packages("devtools")' && \
     sudo Rscript -e 'update.packages(ask = FALSE)'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,22 @@
 # Pull base image
 # To install, use the explicit LTS tag---currently 18.04---when pulling
-# https://hub.docker.com/r/rocker/r-ubuntu
-#FROM rocker/r-ubuntu:18.04 
-FROM rstudio/r-base:4.0.2-bionic 
-#FROM manicaeeg/eeg-docker:latest # rstudio/r-base:x.y.z-distro, see https://github.com/rstudio/r-docker
+FROM rstudio/r-base:3.6-bionic 
+# rstudio/r-base:x.y.z-distro, see https://github.com/rstudio/r-docker
 # This docker is available at https://hub.docker.com/repository/docker/manicaeeg/eeg-docker
 
-
-ARG BUILD_DATE
+ARG BUILD_DATE 
 ARG VCS_REF
 # ARG IMG_DIST
 # ARG BUILD_VERSION
 
 # Labels
-LABEL maintainer="Gian Luigi Somma"
-LABEL org.label-schema.schema-version = "1.0"
-LABEL org.label-schema.name = "EEG-Docker"
-LABEL org.label-schema.description = "A Ubuntu LTS Docker with R for EEG projects"
-LABEL org.label-schema.vcs="https://github.com/EvolEcolGroup/EEG_Docker/"
-
-LABEL org.label-schema.build-date=$BUILD_DATE
-LABEL org.label-schema.vcs-ref=$VCS_REF 
+LABEL maintainer="Gian Luigi Somma" \
+      org.label-schema.schema-version="1.1" \
+      org.label-schema.name="EEG-Docker" \
+      org.label-schema.description="A Ubuntu LTS Docker with R for EEG projects" \
+      org.label-schema.vcs="https://github.com/EvolEcolGroup/EEG_Docker/" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$VCS_REF 
 #LABEL org.label-schema.version = $BUILD_VERSION
 
 # git ssh tar gzip ca-certificates are needed for circleci : https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # To install, use the explicit LTS tag---currently 18.04---when pulling
 # https://hub.docker.com/r/rocker/r-ubuntu
 #FROM rocker/r-ubuntu:18.04 
-FROM manicaeeg/eeg-docker:latest
+FROM rstudio/r-base:4.0.2-bionic 
+#FROM manicaeeg/eeg-docker:latest # rstudio/r-base:x.y.z-distro, see https://github.com/rstudio/r-docker
 # This docker is available at https://hub.docker.com/repository/docker/manicaeeg/eeg-docker
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,62 @@
 # EEG Docker
 
-This project creates a Ubuntu docker image and pushes it to docker.com.
-The image is based on rocker/r-ubuntu:18.04  (see https://hub.docker.com/r/rocker/r-ubuntu) and has Ubuntu 18.04 LTS. In addition, several apt and r packages are pre-installed so to run continuous integration on EEG projects using CircleCI. The docker is pubicly available at: https://hub.docker.com/r/manicaeeg/eeg-docker. 
+Welcome to the docker repository of the [Evolutionary Ecology Group (EEG)](http://www.eeg.zoo.cam.ac.uk/) - [Zoology Department](http://www.zoo.cam.ac.uk), [Cambridge University](http://www.cam.ac.uk).
 
-[![CircleCI](https://img.shields.io/circleci/build/github/EvolEcolGroup/EEG_Docker/master?label=build%20%28master%29&logo=circleci&style=plastic&token=0cab61dc3dfa7b884dfe042a40f22d020ba9dc45)](https://circleci.com/gh/EvolEcolGroup/EEG_Docker/tree/master)
+This project creates a Ubuntu docker image and pushes it to docker.com.
+The image is based on Ubuntu LTS a r (various versions). In addition, several apt and r packages are pre-installed so to run continuous integration on EEG projects using CircleCI. 
+The docker is pubicly available at: https://hub.docker.com/r/manicaeeg/eeg-docker. 
+
+## Getting Started
+
+The images are based on [rstudio/r-docker](https://github.com/rstudio/r-docker) based on Ubuntu 18.04 LTS with r version 4 (or 3.6 as legacy image). In addition, several apt and r packages are pre-installed so to run continuous integration on EEG projects using CircleCI. The dockers are generated and updated via a publicly available GitHub repository: https://github.com/EvolEcolGroup/EEG_Docker
+
+
+### Prerequisities
+
+In order to run this container, you will need docker installed. Based on you OS, you can install it and read a quick guide on the docker.com website:
+
+* [Windows](https://docs.docker.com/windows/started)
+* [OS X](https://docs.docker.com/mac/started/)
+* [Linux](https://docs.docker.com/linux/started/)
+
+[comment]: <> (### Usage)
+[comment]: <> (#### Container Parameters #### Environment Variables #### Volumes #### Useful File Locations)
+
+## Available Images 
+
+You can download `latest` image with
+
+```docker pull manicaeeg/eeg-docker:latest```
+
+Image            | Description                               | Size   | Metrics | Build status 
+---------------- | ----------------------------------------- | ------ | ------- | --------------
+[latest](https://hub.docker.com/repository/docker/manicaeeg/eeg-docker/) | Main docker | ![](https://img.shields.io/docker/image-size/manicaeeg/eeg-docker/latest?style=plastic) | ![](https://img.shields.io/docker/pulls/manicaeeg/eeg-docker?style=plastic) | ![](https://img.shields.io/docker/automated/manicaeeg/eeg-docker?style=plastic)
+
+Additional statistics on the images can be found on the [Docker](https://hub.docker.com/r/manicaeeg/eeg-docker) and [Micro Badger](* [Micro Badger](https://microbadger.com/images/manicaeeg/eeg-docker)) wesbsites.
+
+## Available Tags
+
+You can download one of the following tagged images with
+
+```docker pull manicaeeg/eeg-docker:tag_name```
+
+Tag Name        | Description                               |Ubuntu | R version | Size   | Layers
+---------------- | ----------------------------------------- | -------- | ------| ------- | ------- 
+[latest](https://hub.docker.com/repository/docker/manicaeeg/eeg-docker/) | Main image | 18.04 | 4.0 |![](https://img.shields.io/docker/image-size/manicaeeg/eeg-docker/latest?style=plastic) | ![](https://img.shields.io/microbadger/layers/manicaeeg/eeg-docker/latest?style=plastic) 
+[ubuntu18.04r3.6](https://hub.docker.com/repository/docker/manicaeeg/eeg-docker/) | Legacy tag with R version 3.6 | 18.04 | 3.6 | ![](https://img.shields.io/docker/image-size/manicaeeg/eeg-docker/ubuntu18.04r3.6?style=plastic) | ![](https://img.shields.io/microbadger/layers/manicaeeg/eeg-docker/ubuntu18.04r3.6?style=plastic)
+[ubuntu18.04r4.0](https://hub.docker.com/repository/docker/manicaeeg/eeg-docker/) | As `latest` | 18.04 | 4.0 |![](https://img.shields.io/docker/image-size/manicaeeg/eeg-docker/ubuntu18.04r4.0?style=plastic) | ![](https://img.shields.io/microbadger/layers/manicaeeg/eeg-docker/ubuntu18.04r4.0?style=plastic) 
+
+
+[comment]: <> (## Built With)
+[comment]: <> (List the software and the version numbers that are in this container v0.3.2)
+
+In the `latest image`, Apt and R packages are automatically updated at the beginning of each month.
+In addition to the packages found in the base [rstudio/r-docker](https://github.com/rstudio/r-docker), the additinal installed `apt` and `R` packages are listed in the [Dockerfile](https://github.com/EvolEcolGroup/EEG_Docker/blob/master/Dockerfile).
+
+## Run docker locally
+
+Once you downloaded an image (e.g. `docker pull manicaeeg/eeg-docker:latest`), you can use it locally on your shell.
+For additional help, refer to the [quick guide to the docker command](Docker-quick-guide.md) markdown page.
 
 ## CI tests 
 
@@ -12,3 +65,43 @@ At every commit a test "update_docker" is run, while another two tests are set o
 - manual_test_image
 
 Url for those tests (on circleci) are not posted here since a new manual jobs will be created at each commit. Please, do not bookmark the manual jobs, otherwise you will re-run older version of the repository.
+
+## New dockers
+
+If a new docker needs to be created, remember to change its name and tag in the `config.yml` so to upload it to docker with a new name/tag.
+
+## First build from new repository branch or new docker 
+The first automatic `update_docker` job on the continuous integration will fail becuse there is not yet an image to update.
+Indeed, the first build of each new branch needs to be manually triggered with the `manual_build_deploy_docker` job from CircleCi website. If there are no errors, the image is built and push and all the following commits should sucessfully trigger the `update_docker` job.
+
+## Find Us
+
+* [EEG Website](http://www.eeg.zoo.cam.ac.uk/)
+* [GitHub](https://github.com/EvolEcolGroup/EEG_Docker)
+* [Docker](https://hub.docker.com/r/manicaeeg/eeg-docker)
+* [Micro Badger](https://microbadger.com/images/manicaeeg/eeg-docker)
+
+## Contributing
+
+Please read [CONTRIBUTING.md](https://github.com/EvolEcolGroup/EEG_Docker/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Versioning
+
+For the versions available, see the [tags on this repository](https://github.com/EvolEcolGroup/EEG_Docker/tags). 
+
+## Authors
+
+* **Andrea Manica** - *PI*, *Contributor* - [GitHub](https://github.com/dramanica)
+* **Gian Luigi Somma** - *Initial work* , *Mantainer* - [GitHub](https://github.com/orion434)
+
+See also the list of [contributors](https://github.com/EvolEcolGroup/EEG_Docker/graphs/contributors) who 
+participated in this project.
+
+## License
+
+[comment]: <> (This project is licensed under the MIT License - )
+See the [LICENSE.md](https://github.com/EvolEcolGroup/EEG_Docker/LICENSE.md) file for details.
+
+## Acknowledgments
+
+Part of this readme is based on [Template-README-for-containers.md](https://gist.github.com/PurpleBooth/ea518ae68a49029bae95#file-template-readme-for-containers-md).


### PR DESCRIPTION
This PR update the Docker in severl aspects:

- Add description and rework of the readme.
- Sketch additional tags for current and future docker including info on ubuntu and r version (e.g. `ubuntu18.04-r3.6` and `ubuntu18.04r4.0`). Future update are as easy as updating the Dockerfile line `FROM rstudio/r-base:3.6-bionic` with the r version and ubuntu codename.
- Add info, tag, and badges in the readme on the docker, and images tags.
- Add a markdown guide to the docker command

The current image is about 2.3 Gb with 500-600 layers, while new ones will have about 700-080Mb and ~28-75 layers.
